### PR TITLE
Handle unders more correctly

### DIFF
--- a/lib/Mojolicious/Plugin/PromiseActions.pm
+++ b/lib/Mojolicious/Plugin/PromiseActions.pm
@@ -12,13 +12,16 @@ sub register {
   $app->hook(
     around_action => sub {
       my ($next, $c) = @_;
-      my (@args) = $next->();
+      my $want = wantarray;
+      my @args;
+      if ($want) { @args    = $next->() }
+      else       { $args[0] = $next->() }
       if (blessed($args[0]) && $args[0]->can('then')) {
         my $tx = $c->render_later->tx;
         my $p = Mojo::Promise->resolve($args[0]);
         $p->catch(sub { $c->reply->exception($_[0]) and undef $tx })->wait;
       }
-      return @args;
+      return $want ? @args : $args[0];
     }
   );
 }

--- a/lib/Mojolicious/Plugin/PromiseActions.pm
+++ b/lib/Mojolicious/Plugin/PromiseActions.pm
@@ -11,15 +11,20 @@ sub register {
   my ($elf, $app, $config) = @_;
   $app->hook(
     around_action => sub {
-      my ($next, $c) = @_;
+      my ($next, $c, $action, $last) = @_;
       my $want = wantarray;
       my @args;
       if ($want) { @args    = $next->() }
       else       { $args[0] = $next->() }
       if (blessed($args[0]) && $args[0]->can('then')) {
-        my $tx = $c->render_later->tx;
+        my $tx = $c->tx;
+        $c->render_later if $last;
         my $p = Mojo::Promise->resolve($args[0]);
-        $p->catch(sub { $c->reply->exception($_[0]) and undef $tx })->wait;
+        $p->then(
+          ($last ? undef : sub { $c->continue if $_[0] }),
+          sub { $c->reply->exception($_[0]) and undef $tx },
+        )->wait;
+        return unless $last;
       }
       return $want ? @args : $args[0];
     }

--- a/lib/Mojolicious/Plugin/PromiseActions.pm
+++ b/lib/Mojolicious/Plugin/PromiseActions.pm
@@ -2,6 +2,7 @@ package Mojolicious::Plugin::PromiseActions;
 
 use Mojo::Base 'Mojolicious::Plugin';
 
+use Mojo::Promise;
 use Scalar::Util 'blessed';
 
 our $VERSION = '0.07';
@@ -14,8 +15,8 @@ sub register {
       my (@args) = $next->();
       if (blessed($args[0]) && $args[0]->can('then')) {
         my $tx = $c->render_later->tx;
-        $args[0]->then(undef, sub { $c->reply->exception(pop) and undef $tx });
-        $args[0]->can('wait') && $args[0]->wait;
+        my $p = Mojo::Promise->resolve($args[0]);
+        $p->catch(sub { $c->reply->exception($_[0]) and undef $tx })->wait;
       }
       return @args;
     }

--- a/t/app.t
+++ b/t/app.t
@@ -5,7 +5,6 @@ use Test::Mojo;
 use Mojolicious::Lite;
 use Mojo::Promise;
 
-plugin 'PromiseActions';
 my @values;
 
 app->hook(around_action => sub {
@@ -13,8 +12,9 @@ app->hook(around_action => sub {
     my ($res, $text) = $next->();
     push @values, $res,$text;
     return ($res, $text);
-
 });
+
+plugin 'PromiseActions';
 
 get '/' => sub {
   my $c=shift;

--- a/t/under.t
+++ b/t/under.t
@@ -1,0 +1,37 @@
+BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
+use Test::More;
+use Test::Mojo;
+
+use Mojolicious::Lite;
+use Mojo::Promise;
+
+plugin 'PromiseActions';
+
+my $r = app->routes;
+
+my $ok;
+$r->under('/normal' => sub {
+  my $c = shift;
+  return 1 if $ok;
+  $c->render(text => 'nok');
+  return 0;
+})->get('/' => { text => 'ok' });
+
+my $t = Test::Mojo->new;
+
+# tests to be sure that regular unders work as expected
+
+$ok = 1;
+$t->get_ok('/normal')
+  ->status_is(200)
+  ->content_is('ok');
+
+$ok = 0;
+$t->get_ok('/normal')
+  ->status_is(200)
+  ->content_is('nok');
+
+#TODO add tests for returning promises
+
+done_testing;
+

--- a/t/under.t
+++ b/t/under.t
@@ -22,6 +22,7 @@ $r->under('/promise' => sub {
   my $p = Mojo::Promise->new;
   Mojo::IOLoop->timer(0.1 => sub { $p->resolve });
   return $p->then(sub{
+    die 'ARGH' unless defined $ok;
     $c->render(text => 'nok') unless $ok;
     return $ok;
   });
@@ -52,6 +53,11 @@ $ok = 0;
 $t->get_ok('/promise')
   ->status_is(200)
   ->content_is('nok');
+
+$ok = undef;
+$t->get_ok('/promise')
+  ->status_is(500)
+  ->content_like(qr/ARGH/);
 
 done_testing;
 


### PR DESCRIPTION
This PR does several things:

- handles arbitrary thenables
- propagates context correctly
- DTRT in an under

but it also breaks a test (notably adding context propagation). I've tried to figure out what's broken but I can't. It would also need documentation for the under handling, namely that it breaks returns (since the under must return false to work correctly) and that the promise must resolve to a true value to continue.

We can work from this point, cherry-pick, or whatever, this is just what I have from what I've been working on.